### PR TITLE
enhance console warning multiple packages in shared scope

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,7 +83,7 @@ export const getSharedScope = (enableScopeWarning?: boolean) => {
 
   const sharedScope = __webpack_share_scopes__[SHARED_SCOPE_NAME];
   if (enableScopeWarning) {
-    warnDuplicatePkg(sharedScope);
+    warnDuplicatePkg();
   }
 
   return sharedScope;

--- a/packages/core/src/warnDuplicatePkg.ts
+++ b/packages/core/src/warnDuplicatePkg.ts
@@ -1,28 +1,82 @@
-interface Package {
+interface InstanceInfo {
   from: string;
   eager?: boolean;
   loaded?: number;
 }
 
-interface Packages {
-  [key: string]: {
-    [key: string]: Package;
-  };
+interface LoadedInstance {
+  [version: string]: InstanceInfo;
 }
+
+interface Package {
+  [pkgName: string]: LoadedInstance;
+}
+
+interface ToAlign {
+  [appName: string]: string;
+}
+declare let __webpack_share_scopes__: { [x: string]: any };
+
+const getWebpackScope = () => {
+  return __webpack_share_scopes__['default'];
+};
+
+const prepareUpdateCommands = (entries: [string, LoadedInstance][]) => {
+  const toAlign: ToAlign = {};
+  const visitedPackages: Record<string, string> = {};
+
+  entries.forEach(([pkgName, pkg]) => {
+    const loadedInstances = Object.entries(pkg);
+
+    if (loadedInstances.length > 1) {
+      loadedInstances.forEach(([, instanceInfo]) => {
+        const loadedApp = instanceInfo.from;
+
+        if (loadedApp && loadedApp !== 'insights-chrome' && !(visitedPackages[pkgName] === loadedApp)) {
+          if (toAlign[loadedApp]) {
+            toAlign[loadedApp] = `${toAlign[loadedApp]},${pkgName}`;
+          } else {
+            toAlign[loadedApp] = pkgName;
+          }
+
+          visitedPackages[pkgName] = loadedApp;
+        }
+      });
+    }
+  });
+
+  return toAlign;
+};
 
 /**
  * Warns applications using the shared scope if they have packages multiple times
  */
-export const warnDuplicatePkg = (packages: Packages) => {
+export const warnDuplicatePkg = () => {
+  const packages: Package = getWebpackScope();
   const entries = Object.entries(packages);
+  const updateCommands: ToAlign = prepareUpdateCommands(entries);
 
-  entries.forEach(([pkgName, versions]) => {
-    const instances = Object.keys(versions);
-    if (instances.length > 1) {
-      console.warn(
-        `[SCALPRUM]: You have ${pkgName} package that is being loaded into browser multiple times. You might want to align your version with the chrome one.`
+  const pkgNames = Object.keys(updateCommands);
+  if (pkgNames.length) {
+    console.group(
+      `%c [SCALPRUM]: You have following packages that is being loaded into browser multiple times. You might want to align your version with the chrome one`,
+      'font-size:20px; background:#F9F9F9; color:#581845; padding:1px; border-radius:1px;'
+    );
+
+    const apps = Object.entries(updateCommands);
+
+    apps.forEach(([appName, packages]) => {
+      console.group(
+        `[SCALPRUM]: To align ${appName} application's package dependency versions to the chroming app instance version, please run following command`
       );
-      console.warn(`[SCALPRUM]: All packages instances:`, versions);
-    }
-  });
+      console.warn(
+        `%c insights-interact run alignPackages --app=${appName} --packages=${packages} `,
+        'font-size:15px; background:#F9F9F9; color:#581845; padding:1px; border-radius:1px;'
+      );
+      console.groupEnd();
+    });
+
+    console.warn(`[SCALPRUM]: All packages in the shared scope:`, packages);
+    console.groupEnd();
+  }
 };


### PR DESCRIPTION
This PR is intended to enhance the console warning of the packages loaded multiple times into shared scope. Now the warning is cleaner, and easy to spot, and also includes a command for insights-interact-tool that will make aligning the versions easier. Due to a problem with not being able to access all package versions as keys of shared scope, this feature will be 'opt in' for micro-apps. They need to enable this by explicitly importing the module **getSharedScope** in dev environment.