### PR TITLE
build: fix ci commands execution order

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -42,7 +42,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
         GITHUB_TOKEN: ${{ inputs.gh_token }}
-      run: npx nx affected --base=last-release --parallel=1 --target=version --postTargets=build,syncDependencies,npm,github --trackDeps
+      run: npx nx affected --base=last-release --parallel=1 --target=version --postTargets=syncDependencies,build,npm,github --trackDeps
     - name: Tag last-release
       shell: bash
       run: |


### PR DESCRIPTION
Make sure the dist dir has the correct package json files before pushed to NPM.